### PR TITLE
[release-ocm-2.13] NO-ISSUE: CVE-2024-45339 Bump github.com/golang/glog to v1.2.4 through indirect dependency conversion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
-	github.com/golang/glog v1.2.0 // indirect
+	github.com/golang/glog v1.2.4 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2310,8 +2310,8 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/glog v1.1.0/go.mod h1:pfYeQZ3JWZoXTV5sFc986z3HTpwQs9At6P4ImfuP3NQ=
 github.com/golang/glog v1.1.2/go.mod h1:zR+okUeTbrL6EL3xHUDxZuEtGv04p5shwip1+mL/rLQ=
-github.com/golang/glog v1.2.0 h1:uCdmnmatrKCgMBlM4rMuJZWOkPDqdbZPnrMXDY4gI68=
-github.com/golang/glog v1.2.0/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
+github.com/golang/glog v1.2.4 h1:CNNw5U8lSiiBk7druxtSHHTsRWcxKoac6kZKm2peBBc=
+github.com/golang/glog v1.2.4/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/vendor/github.com/golang/glog/glog.go
+++ b/vendor/github.com/golang/glog/glog.go
@@ -76,7 +76,7 @@
 //			-log_backtrace_at=gopherflakes.go:234
 //		A stack trace will be written to the Info log whenever execution
 //		hits one of these statements. (Unlike with -vmodule, the ".go"
-//		must bepresent.)
+//		must be present.)
 //	-v=0
 //		Enable V-leveled logging at the specified level.
 //	-vmodule=""

--- a/vendor/github.com/golang/glog/glog_file_nonwindows.go
+++ b/vendor/github.com/golang/glog/glog_file_nonwindows.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package glog
+
+import "os/user"
+
+// shouldRegisterStderrSink determines whether we should register a log sink that writes to stderr.
+// Today, this always returns true on non-Windows platforms, as it specifically checks for a
+// condition that is only present on Windows.
+func shouldRegisterStderrSink() bool {
+	return true
+}
+
+func lookupUser() string {
+	if current, err := user.Current(); err == nil {
+		return current.Username
+	}
+	return ""
+}

--- a/vendor/github.com/golang/glog/glog_file_windows.go
+++ b/vendor/github.com/golang/glog/glog_file_windows.go
@@ -1,0 +1,43 @@
+//go:build windows
+
+package glog
+
+import (
+	"os"
+	"syscall"
+)
+
+// shouldRegisterStderrSink determines whether we should register a log sink that writes to stderr.
+// Today, this checks if stderr is "valid", in that it maps to a non-NULL Handle.
+// Windows Services are spawned without Stdout and Stderr, so any attempt to use them equates to
+// referencing an invalid file Handle.
+// os.Stderr's FD is derived from a call to `syscall.GetStdHandle(syscall.STD_ERROR_HANDLE)`.
+// Documentation[1] for the GetStdHandle function indicates the return value may be NULL if the
+// application lacks the standard handle, so consider Stderr valid if its FD is non-NULL.
+// [1]: https://learn.microsoft.com/en-us/windows/console/getstdhandle
+func shouldRegisterStderrSink() bool {
+	return os.Stderr.Fd() != 0
+}
+
+// This follows the logic in the standard library's user.Current() function, except
+// that it leaves out the potentially expensive calls required to look up the user's
+// display name in Active Directory.
+func lookupUser() string {
+	token, err := syscall.OpenCurrentProcessToken()
+	if err != nil {
+		return ""
+	}
+	defer token.Close()
+	tokenUser, err := token.GetTokenUser()
+	if err != nil {
+		return ""
+	}
+	username, _, accountType, err := tokenUser.User.Sid.LookupAccount("")
+	if err != nil {
+		return ""
+	}
+	if accountType != syscall.SidTypeUser {
+		return ""
+	}
+	return username
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -231,7 +231,7 @@ github.com/golang-jwt/jwt
 # github.com/golang-jwt/jwt/v4 v4.5.2
 ## explicit; go 1.16
 github.com/golang-jwt/jwt/v4
-# github.com/golang/glog v1.2.0
+# github.com/golang/glog v1.2.4
 ## explicit; go 1.19
 github.com/golang/glog
 github.com/golang/glog/internal/logsink


### PR DESCRIPTION
Bump `github.com/golang/glog` to `v1.2.4` to fix `CVE-2024-45339` through indirect dependency conversion