### PR TITLE
[release-ocm-2.12] NO-ISSUE: CVE-2024-27304 Bump github.com/jackc/pgx/v4 to v4.18.2 through indirect dependency conversion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,7 @@ require (
 	github.com/jackc/pgproto3/v2 v2.3.3 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/pgtype v1.14.0 // indirect
-	github.com/jackc/pgx/v4 v4.18.1 // indirect
+	github.com/jackc/pgx/v4 v4.18.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2758,8 +2758,9 @@ github.com/jackc/pgx/v4 v4.11.0/go.mod h1:i62xJgdrtVDsnL3U8ekyrQXEwGNTRoG7/8r+CI
 github.com/jackc/pgx/v4 v4.12.0/go.mod h1:fE547h6VulLPA3kySjfnSG/e2D861g/50JlVUa/ub60=
 github.com/jackc/pgx/v4 v4.12.1-0.20210724153913-640aa07df17c/go.mod h1:1QD0+tgSXP7iUjYm9C1NxKhny7lq6ee99u/z+IHFcgs=
 github.com/jackc/pgx/v4 v4.16.0/go.mod h1:N0A9sFdWzkw/Jy1lwoiB64F2+ugFZi987zRxcPez/wI=
-github.com/jackc/pgx/v4 v4.18.1 h1:YP7G1KABtKpB5IHrO9vYwSrCOhs7p3uqhvhhQBptya0=
 github.com/jackc/pgx/v4 v4.18.1/go.mod h1:FydWkUyadDmdNH/mHnGob881GawxeEm7TcMCzkb+qQE=
+github.com/jackc/pgx/v4 v4.18.2 h1:xVpYkNR5pk5bMCZGfClbO962UIqVABcAGt7ha1s/FeU=
+github.com/jackc/pgx/v4 v4.18.2/go.mod h1:Ey4Oru5tH5sB6tV7hDmfWFahwF15Eb7DNXlRKx2CkVw=
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=

--- a/vendor/github.com/jackc/pgx/v4/CHANGELOG.md
+++ b/vendor/github.com/jackc/pgx/v4/CHANGELOG.md
@@ -1,3 +1,26 @@
+# 4.18.2 (March 4, 2024)
+
+Fix CVE-2024-27289
+
+SQL injection can occur when all of the following conditions are met:
+
+1. The non-default simple protocol is used.
+2. A placeholder for a numeric value must be immediately preceded by a minus.
+3. There must be a second placeholder for a string value after the first placeholder; both must be on the same line.
+4. Both parameter values must be user-controlled.
+
+Thanks to Paul Gerste for reporting this issue.
+
+Fix CVE-2024-27304
+
+SQL injection can occur if an attacker can cause a single query or bind message to exceed 4 GB in size. An integer
+overflow in the calculated message size can cause the one large message to be sent as multiple messages under the
+attacker's control.
+
+Thanks to Paul Gerste for reporting this issue.
+
+* Fix *dbTx.Exec not checking if it is already closed
+
 # 4.18.1 (February 27, 2023)
 
 * Fix: Support pgx v4 and v5 stdlib in same program (Tomáš Procházka)

--- a/vendor/github.com/jackc/pgx/v4/README.md
+++ b/vendor/github.com/jackc/pgx/v4/README.md
@@ -134,7 +134,7 @@ In addition, there are tests specific for PgBouncer that will be executed if `PG
 
 ## Supported Go and PostgreSQL Versions
 
-pgx supports the same versions of Go and PostgreSQL that are supported by their respective teams. For [Go](https://golang.org/doc/devel/release.html#policy) that is the two most recent major releases and for [PostgreSQL](https://www.postgresql.org/support/versioning/) the major releases in the last 5 years. This means pgx supports Go 1.16 and higher and PostgreSQL 10 and higher. pgx also is tested against the latest version of [CockroachDB](https://www.cockroachlabs.com/product/).
+pgx supports the same versions of Go and PostgreSQL that are supported by their respective teams. For [Go](https://golang.org/doc/devel/release.html#policy) that is the two most recent major releases and for [PostgreSQL](https://www.postgresql.org/support/versioning/) the major releases in the last 5 years. This means pgx supports Go 1.17 and higher and PostgreSQL 10 and higher. pgx also is tested against the latest version of [CockroachDB](https://www.cockroachlabs.com/product/).
 
 ## Version Policy
 

--- a/vendor/github.com/jackc/pgx/v4/internal/sanitize/sanitize.go
+++ b/vendor/github.com/jackc/pgx/v4/internal/sanitize/sanitize.go
@@ -58,6 +58,10 @@ func (q *Query) Sanitize(args ...interface{}) (string, error) {
 				return "", fmt.Errorf("invalid arg type: %T", arg)
 			}
 			argUse[argIdx] = true
+
+			// Prevent SQL injection via Line Comment Creation
+			// https://github.com/jackc/pgx/security/advisories/GHSA-m7wr-2xf7-cm9p
+			str = "(" + str + ")"
 		default:
 			return "", fmt.Errorf("invalid Part type: %T", part)
 		}

--- a/vendor/github.com/jackc/pgx/v4/tx.go
+++ b/vendor/github.com/jackc/pgx/v4/tx.go
@@ -264,6 +264,10 @@ func (tx *dbTx) Rollback(ctx context.Context) error {
 
 // Exec delegates to the underlying *Conn
 func (tx *dbTx) Exec(ctx context.Context, sql string, arguments ...interface{}) (commandTag pgconn.CommandTag, err error) {
+	if tx.closed {
+		return pgconn.CommandTag{}, ErrTxClosed
+	}
+
 	return tx.conn.Exec(ctx, sql, arguments...)
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -310,8 +310,8 @@ github.com/jackc/pgservicefile
 # github.com/jackc/pgtype v1.14.0
 ## explicit; go 1.13
 github.com/jackc/pgtype
-# github.com/jackc/pgx/v4 v4.18.1
-## explicit; go 1.13
+# github.com/jackc/pgx/v4 v4.18.2
+## explicit; go 1.17
 github.com/jackc/pgx/v4
 github.com/jackc/pgx/v4/internal/sanitize
 github.com/jackc/pgx/v4/stdlib


### PR DESCRIPTION
Bump `github.com/jackc/pgx/v4` to `v4.18.2` to fix `CVE-2024-27304` through indirect dependency conversion